### PR TITLE
feat(shiori): Add pipe-keep-segments option while use pipe output

### DIFF
--- a/bin/shiori/i18n/en-US/shiori.ftl
+++ b/bin/shiori/i18n/en-US/shiori.ftl
@@ -36,3 +36,4 @@ download-output-output = Output filename
 download-output-pipe = Pipe to stdout
 download-output-pipe-mux = Mux with ffmpeg. Only works when `--pipe` is set.
 download-output-pipe-to = Pipe to a file
+download-output-pipe-keep-segments = When using pipe output, keep downloaded segments.

--- a/bin/shiori/i18n/zh-CN/shiori.ftl
+++ b/bin/shiori/i18n/zh-CN/shiori.ftl
@@ -35,3 +35,4 @@ download-output-output = 输出文件名
 download-output-pipe = 输出到标准输出
 download-output-pipe-mux = 使用 FFmpeg 混流，仅在 `--pipe` 生效时有效
 download-output-pipe-to = 使用 Pipe 输出到指定路径
+download-output-pipe-keep-segments = 使用 Pipe 输出时，保留已下载的分片。

--- a/bin/shiori/src/commands/download.rs
+++ b/bin/shiori/src/commands/download.rs
@@ -298,7 +298,7 @@ pub struct OutputOptions {
 
     #[clap(long, default_value_t = false)]
     #[clap(about_ll = "download-output-pipe-keep-segments")]
-    pub keep_segments: bool,
+    pub pipe_keep_segments: bool,
 }
 
 #[derive(Args, Clone, Debug, Default)]
@@ -335,11 +335,11 @@ impl OutputOptions {
             IoriMerger::skip()
         } else if self.output_mode.pipe || self.output_mode.pipe_mux || self.output_mode.pipe_to.is_some() {
             if self.output_mode.pipe_mux {
-                IoriMerger::pipe_mux(!self.keep_segments, self.output_mode.pipe_to.unwrap_or("-".into()), None)
+                IoriMerger::pipe_mux(!self.pipe_keep_segments, self.output_mode.pipe_to.unwrap_or("-".into()), None)
             } else if let Some(file) = self.output_mode.pipe_to {
-                IoriMerger::pipe_to_file(!self.keep_segments, file)
+                IoriMerger::pipe_to_file(!self.pipe_keep_segments, file)
             } else {
-                IoriMerger::pipe(true)
+                IoriMerger::pipe(!self.pipe_keep_segments)
             }
         } else if let Some(mut output) = self.output_mode.output {
             if output.exists() {

--- a/bin/shiori/src/commands/download.rs
+++ b/bin/shiori/src/commands/download.rs
@@ -139,8 +139,8 @@ where
         if self.decrypt.key.is_none() {
             self.decrypt.key = from.decrypt.key;
         }
-        if self.output.output.is_none() {
-            self.output.output = from.output.output;
+        if self.output.output_mode.output.is_none() {
+            self.output.output_mode.output = from.output.output_mode.output;
         }
         self.extra.playlist_type = from.extra.playlist_type;
 
@@ -292,8 +292,18 @@ pub struct ExtraOptions {
 }
 
 #[derive(Args, Clone, Debug, Default)]
-#[group(multiple = false)]
 pub struct OutputOptions {
+    #[clap(flatten)]
+    pub output_mode: OutputModeOptions,
+
+    #[clap(long, default_value_t = false)]
+    #[clap(about_ll = "download-output-pipe-keep-segments")]
+    pub keep_segments: bool,
+}
+
+#[derive(Args, Clone, Debug, Default)]
+#[group(multiple = false)]
+pub struct OutputModeOptions {
     #[clap(long)]
     #[clap(about_ll = "download-output-no-merge")]
     pub no_merge: bool,
@@ -321,17 +331,17 @@ pub struct OutputOptions {
 
 impl OutputOptions {
     pub fn into_merger(self) -> IoriMerger {
-        if self.no_merge {
+        if self.output_mode.no_merge {
             IoriMerger::skip()
-        } else if self.pipe || self.pipe_mux || self.pipe_to.is_some() {
-            if self.pipe_mux {
-                IoriMerger::pipe_mux(true, self.pipe_to.unwrap_or("-".into()), None)
-            } else if let Some(file) = self.pipe_to {
-                IoriMerger::pipe_to_file(true, file)
+        } else if self.output_mode.pipe || self.output_mode.pipe_mux || self.output_mode.pipe_to.is_some() {
+            if self.output_mode.pipe_mux {
+                IoriMerger::pipe_mux(!self.keep_segments, self.output_mode.pipe_to.unwrap_or("-".into()), None)
+            } else if let Some(file) = self.output_mode.pipe_to {
+                IoriMerger::pipe_to_file(!self.keep_segments, file)
             } else {
                 IoriMerger::pipe(true)
             }
-        } else if let Some(mut output) = self.output {
+        } else if let Some(mut output) = self.output_mode.output {
             if output.exists() {
                 log::warn!("Output file exists. Will add suffix automatically.");
                 let original_extension = output.extension();
@@ -342,7 +352,7 @@ impl OutputOptions {
                 output = output.with_extension(new_extension);
             }
 
-            if self.concat {
+            if self.output_mode.concat {
                 IoriMerger::concat(output, false)
             } else {
                 IoriMerger::auto(output, false)
@@ -369,6 +379,7 @@ pub async fn download(me: ShioriDownloadCommand, shiori_args: ShioriArgs) -> any
 
     let mut namer = me
         .output
+        .output_mode
         .output
         .as_ref()
         .map(|p| DuplicateOutputFileNamer::new(p.clone()));
@@ -378,7 +389,7 @@ pub async fn download(me: ShioriDownloadCommand, shiori_args: ShioriArgs) -> any
         let mut cmd = me.clone().merge(command);
         if let Some(namer) = namer.as_mut() {
             let output = namer.next_path();
-            cmd.output.output = Some(output);
+            cmd.output.output_mode.output = Some(output);
         }
         cmd.download().await?;
     }
@@ -409,7 +420,9 @@ where
                 playlist_type: Some(data.playlist_type),
             },
             output: OutputOptions {
-                output: data.title.map(|title| {
+                output_mode: OutputModeOptions {
+                    pipe_mux: data.streams_hint.unwrap_or(1) > 1,
+                    output: data.title.map(|title| {
                     let path = std::path::Path::new(&title);
                     // Replace invalid characters with underscores
                     let filename = path
@@ -433,8 +446,9 @@ where
                         })
                         .unwrap_or_else(|| title.clone());
                     filename.into()
-                }),
-                pipe_mux: data.streams_hint.unwrap_or(1) > 1,
+                    }),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             url: data.playlist_url,

--- a/bin/shiori/src/commands/download.rs
+++ b/bin/shiori/src/commands/download.rs
@@ -421,32 +421,32 @@ where
             },
             output: OutputOptions {
                 output_mode: OutputModeOptions {
-                    pipe_mux: data.streams_hint.unwrap_or(1) > 1,
                     output: data.title.map(|title| {
-                    let path = std::path::Path::new(&title);
-                    // Replace invalid characters with underscores
-                    let filename = path
-                        .file_name()
-                        .and_then(|name| name.to_str())
-                        .map(|name| {
-                            name.replace(
-                                |c: char| {
-                                    c == '/'
-                                        || c == '\\'
-                                        || c == ':'
-                                        || c == '*'
-                                        || c == '?'
-                                        || c == '"'
-                                        || c == '<'
-                                        || c == '>'
-                                        || c == '|'
-                                },
-                                "_",
-                            )
-                        })
-                        .unwrap_or_else(|| title.clone());
-                    filename.into()
+                        let path = std::path::Path::new(&title);
+                        // Replace invalid characters with underscores
+                        let filename = path
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .map(|name| {
+                                name.replace(
+                                    |c: char| {
+                                        c == '/'
+                                            || c == '\\'
+                                            || c == ':'
+                                            || c == '*'
+                                            || c == '?'
+                                            || c == '"'
+                                            || c == '<'
+                                            || c == '>'
+                                            || c == '|'
+                                    },
+                                    "_",
+                                )
+                            })
+                            .unwrap_or_else(|| title.clone());
+                        filename.into()
                     }),
+                    pipe_mux: data.streams_hint.unwrap_or(1) > 1,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/crates/iori/src/merge/pipe.rs
+++ b/crates/iori/src/merge/pipe.rs
@@ -188,7 +188,9 @@ impl PipeMerger {
             let video_handle = tokio::spawn(async move {
                 while let Some((mut reader, _, invalidate)) = video_receiver.recv().await {
                     tokio::io::copy(&mut reader, &mut video_pipe).await.unwrap();
-                    invalidate.await.unwrap();
+                    if recycle{
+                        invalidate.await.unwrap();
+                    }
                 }
             });
 
@@ -199,7 +201,9 @@ impl PipeMerger {
 
                 while let Some((mut reader, _, invalidate)) = audio_receiver.recv().await {
                     tokio::io::copy(&mut reader, &mut audio_pipe).await.unwrap();
-                    invalidate.await.unwrap();
+                    if recycle{
+                        invalidate.await.unwrap();
+                    }
                 }
             });
 

--- a/crates/iori/src/merge/pipe.rs
+++ b/crates/iori/src/merge/pipe.rs
@@ -188,7 +188,7 @@ impl PipeMerger {
             let video_handle = tokio::spawn(async move {
                 while let Some((mut reader, _, invalidate)) = video_receiver.recv().await {
                     tokio::io::copy(&mut reader, &mut video_pipe).await.unwrap();
-                    if recycle{
+                    if recycle {
                         invalidate.await.unwrap();
                     }
                 }
@@ -201,7 +201,7 @@ impl PipeMerger {
 
                 while let Some((mut reader, _, invalidate)) = audio_receiver.recv().await {
                     tokio::io::copy(&mut reader, &mut audio_pipe).await.unwrap();
-                    if recycle{
+                    if recycle {
                         invalidate.await.unwrap();
                     }
                 }


### PR DESCRIPTION
## 动机/需求

- 想边直播保留分片边使用ffmpeg推流，尤其是nicovideo平台

## 变更

`bin/shiori/src/commands/download.rs`

- 将OutputOptions的几个互斥输出模式选项变为 OutputMode 的子选项。使用flatten展开，对--help显示没有影响
- 并在OutputOptions 中添加了 pipe-keep-segments 的选项